### PR TITLE
Fixes panic when subject block is empty in tls_cert_request

### DIFF
--- a/tls/resource_cert_request.go
+++ b/tls/resource_cert_request.go
@@ -82,7 +82,10 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	if len(subjectConfs) != 1 {
 		return fmt.Errorf("must have exactly one 'subject' block")
 	}
-	subjectConf := subjectConfs[0].(map[string]interface{})
+	subjectConf, ok := subjectConfs[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("subject block cannot be empty")
+	}
 	subject, err := nameFromResourceData(subjectConf)
 	if err != nil {
 		return fmt.Errorf("invalid subject block: %s", err)


### PR DESCRIPTION
Fixes issue #1. Tested locally with `tls_cert_request` with an empty `subject` block, `terraform apply` produced error message rather than panicking. Also tested a non-error situation.