### PR TITLE
Fix handling of default values in subject

### DIFF
--- a/tls/provider.go
+++ b/tls/provider.go
@@ -32,35 +32,34 @@ func hashForState(value string) string {
 func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
 	result := &pkix.Name{}
 
-	if value := nameMap["common_name"]; value != nil {
+	if value := nameMap["common_name"]; value != "" {
 		result.CommonName = value.(string)
 	}
-	if value := nameMap["organization"]; value != nil {
+	if value := nameMap["organization"]; value != "" {
 		result.Organization = []string{value.(string)}
 	}
-	if value := nameMap["organizational_unit"]; value != nil {
+	if value := nameMap["organizational_unit"]; value != "" {
 		result.OrganizationalUnit = []string{value.(string)}
 	}
-	if value := nameMap["street_address"]; value != nil {
-		valueI := value.([]interface{})
-		result.StreetAddress = make([]string, len(valueI))
-		for i, vi := range valueI {
+	if value := nameMap["street_address"].([]interface{}); len(value) > 0 {
+		result.StreetAddress = make([]string, len(value))
+		for i, vi := range value {
 			result.StreetAddress[i] = vi.(string)
 		}
 	}
-	if value := nameMap["locality"]; value != nil {
+	if value := nameMap["locality"]; value != "" {
 		result.Locality = []string{value.(string)}
 	}
-	if value := nameMap["province"]; value != nil {
+	if value := nameMap["province"]; value != "" {
 		result.Province = []string{value.(string)}
 	}
-	if value := nameMap["country"]; value != nil {
+	if value := nameMap["country"]; value != "" {
 		result.Country = []string{value.(string)}
 	}
-	if value := nameMap["postal_code"]; value != nil {
+	if value := nameMap["postal_code"]; value != "" {
 		result.PostalCode = []string{value.(string)}
 	}
-	if value := nameMap["serial_number"]; value != nil {
+	if value := nameMap["serial_number"]; value != "" {
 		result.SerialNumber = value.(string)
 	}
 

--- a/tls/resource_cert_request_test.go
+++ b/tls/resource_cert_request_test.go
@@ -17,7 +17,7 @@ func TestCertRequest(t *testing.T) {
 		Steps: []r.TestStep{
 			r.TestStep{
 				Config: fmt.Sprintf(`
-                    resource "tls_cert_request" "test" {
+                    resource "tls_cert_request" "test1" {
                         subject {
                             common_name = "example.com"
                             organization = "Example, Inc"
@@ -45,16 +45,16 @@ func TestCertRequest(t *testing.T) {
 %s
 EOT
                     }
-                    output "key_pem" {
-                        value = "${tls_cert_request.test.cert_request_pem}"
+                    output "key_pem_1" {
+                        value = "${tls_cert_request.test1.cert_request_pem}"
                     }
                 `, testPrivateKey),
 				Check: func(s *terraform.State) error {
-					gotUntyped := s.RootModule().Outputs["key_pem"].Value
+					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 
 					got, ok := gotUntyped.(string)
 					if !ok {
-						return fmt.Errorf("output for \"key_pem\" is not a string")
+						return fmt.Errorf("output for \"key_pem_1\" is not a string")
 					}
 
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
@@ -111,6 +111,75 @@ EOT
 					}
 					if expected, got := "127.0.0.2", csr.IPAddresses[1].String(); got != expected {
 						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+					}
+
+					return nil
+				},
+			},
+			r.TestStep{
+				Config: fmt.Sprintf(`
+                    resource "tls_cert_request" "test2" {
+                        subject {
+						serial_number = "42"
+						}
+
+                        key_algorithm = "RSA"
+                        private_key_pem = <<EOT
+%s
+EOT
+                    }
+                    output "key_pem_2" {
+                        value = "${tls_cert_request.test2.cert_request_pem}"
+                    }
+                `, testPrivateKey),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["key_pem_2"].Value
+
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem_2\" is not a string")
+					}
+
+					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
+						return fmt.Errorf("key is missing CSR PEM preamble")
+					}
+					block, _ := pem.Decode([]byte(got))
+					csr, err := x509.ParseCertificateRequest(block.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing CSR: %s", err)
+					}
+					if expected, got := "42", csr.Subject.SerialNumber; got != expected {
+						return fmt.Errorf("incorrect subject serial number: expected %v, got %v", expected, got)
+					}
+					if expected, got := "", csr.Subject.CommonName; got != expected {
+						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.Organization); got != expected {
+						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.OrganizationalUnit); got != expected {
+						return fmt.Errorf("incorrect subject organizational unit: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.StreetAddress); got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.Locality); got != expected {
+						return fmt.Errorf("incorrect subject locality: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.Province); got != expected {
+						return fmt.Errorf("incorrect subject province: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.Country); got != expected {
+						return fmt.Errorf("incorrect subject country: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.Subject.PostalCode); got != expected {
+						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.DNSNames); got != expected {
+						return fmt.Errorf("incorrect number of DNS names: expected %v, got %v", expected, got)
+					}
+					if expected, got := 0, len(csr.IPAddresses); got != expected {
+						return fmt.Errorf("incorrect number of IP addresses: expected %v, got %v", expected, got)
 					}
 
 					return nil


### PR DESCRIPTION
When creating a new certificate request or self-signed certificate, the `subject` map has a number of fields, all of which are optional. `provider.go` has a function `nameFromResourceData` that creates a `pkix.Name` struct from the data in the `subject` map. 

That function tests for missing values by comparing with `nil`. This is incorrect, as missing string values come through as `""` and missing list values come through as `[]`. The result of this error is that the following HCL produces a certificate with the Subject Name `C=, ST=, L=/postalCode=, O=MongoDB, OU=, CN=Example CA`:

```
resource "tls_private_key" "ca" {
  algorithm = "RSA"
  rsa_bits = 2048
}
resource "tls_self_signed_cert" "ca" {
  is_ca_certificate = true
  key_algorithm = "RSA"
  allowed_uses = [
    "cert_signing",
    "ocsp_signing"
  ]
  private_key_pem = "${tls_private_key.ca.private_key_pem}"
  "subject" {
    organization = "MongoDB"
    common_name = "Example CA"
  }
  validity_period_hours = 8760
}
``` 

With this fix, the Subject Name is `O=MongoDB, CN=Example CA` as it should be.
