### PR TITLE
Documentation update for tls_cert_request

### DIFF
--- a/website/docs/r/cert_request.html.md
+++ b/website/docs/r/cert_request.html.md
@@ -59,7 +59,7 @@ a nested configuration block whose structure is described below.
 
 The nested `subject` block accepts the following arguments, all optional, with their meaning
 corresponding to the similarly-named attributes defined in
-[RFC5290](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
+[RFC5280](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
 
 * `common_name` (string)
 

--- a/website/docs/r/cert_request.html.md
+++ b/website/docs/r/cert_request.html.md
@@ -79,12 +79,12 @@ corresponding to the similarly-named attributes defined in
 
 * `serial_number` (string)
 
--> **Note:** Versions of this provider compiled by Go 1.9.x or older may
-generate a certificate request which cannot be validated by your Certificate
-Authority if the `*` character is used in any of the `subject` fields, for
-example as part of the `common_name` when generating a request for a wildcard
-certificate. Strings containing a `*` and passed to the `dns_names` argument
-are encoded correctly.
+-> **Note:** Versions of this provider prior to 1.2.0 may generate a
+certificate request which cannot be validated by your Certificate Authority if
+the `*` character is used in any of the `subject` fields, for example as part
+of the `common_name` when generating a request for a wildcard certificate.
+Strings containing a `*` and passed to the `dns_names` argument are encoded
+correctly.
 
 ## Attributes Reference
 

--- a/website/docs/r/cert_request.html.md
+++ b/website/docs/r/cert_request.html.md
@@ -79,6 +79,13 @@ corresponding to the similarly-named attributes defined in
 
 * `serial_number` (string)
 
+-> **Note:** Versions of this provider compiled by Go 1.9.x or older may
+generate a certificate request which cannot be validated by your Certificate
+Authority if the `*` character is used in any of the `subject` fields, for
+example as part of the `common_name` when generating a request for a wildcard
+certificate. Strings containing a `*` and passed to the `dns_names` argument
+are encoded correctly.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
- Fix a typo in the link name to RFC5280
- Add a note about using `tls_cert_request` with `*` characters

Primarily for #21 