### PR TITLE
Fix #3: change subject fields to be lists of strings

### DIFF
--- a/tls/provider.go
+++ b/tls/provider.go
@@ -32,36 +32,22 @@ func hashForState(value string) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// Create a PKIX Name from the subject resource
 func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
 	result := &pkix.Name{}
 
 	if value := nameMap["common_name"]; value != "" {
 		result.CommonName = value.(string)
 	}
-	if value := nameMap["organization"]; value != "" {
-		result.Organization = []string{value.(string)}
-	}
-	if value := nameMap["organizational_unit"]; value != "" {
-		result.OrganizationalUnit = []string{value.(string)}
-	}
-	if value := nameMap["street_address"].([]interface{}); len(value) > 0 {
-		result.StreetAddress = make([]string, len(value))
-		for i, vi := range value {
-			result.StreetAddress[i] = vi.(string)
-		}
-	}
-	if value := nameMap["locality"]; value != "" {
-		result.Locality = []string{value.(string)}
-	}
-	if value := nameMap["province"]; value != "" {
-		result.Province = []string{value.(string)}
-	}
-	if value := nameMap["country"]; value != "" {
-		result.Country = []string{value.(string)}
-	}
-	if value := nameMap["postal_code"]; value != "" {
-		result.PostalCode = []string{value.(string)}
-	}
+
+	result.Organization = convertResourceToStrings("organization", nameMap)
+	result.OrganizationalUnit = convertResourceToStrings("organizational_unit", nameMap)
+	result.StreetAddress = convertResourceToStrings("street_address", nameMap)
+	result.Locality = convertResourceToStrings("locality", nameMap)
+	result.Province = convertResourceToStrings("province", nameMap)
+	result.Country = convertResourceToStrings("country", nameMap)
+	result.PostalCode = convertResourceToStrings("postal_code", nameMap)
+
 	if value := nameMap["serial_number"]; value != "" {
 		result.SerialNumber = value.(string)
 	}
@@ -69,12 +55,33 @@ func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
 	return result, nil
 }
 
+// Convert a Resource that is a list of strings to a []string
+func convertResourceToStrings(key string, in map[string]interface{}) []string {
+	// start with a map of string to interface{} and look up the interface{} for the given string
+	// then convert the interface() to a slice of interface{}
+	// then convert the slice of interface{} to a slice of string, or nil if no elements
+	// panic at any step if something isn't right
+	v := in[key].([]interface{})
+	if len(v) == 0 {
+		return nil
+	}
+	out := make([]string, len(v))
+	for i, vi := range v {
+		out[i] = vi.(string)
+	}
+	return out
+}
+
 var nameSchema *schema.Resource = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"organization": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
 		},
 		"common_name": &schema.Schema{
 			Type:     schema.TypeString,
@@ -82,37 +89,57 @@ var nameSchema *schema.Resource = &schema.Resource{
 			ForceNew: true,
 		},
 		"organizational_unit": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-		},
-		"street_address": &schema.Schema{
-			Type:     schema.TypeList,
-			Optional: true,
+			Type: schema.TypeList,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
+		},
+		"street_address": &schema.Schema{
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional: true,
 			ForceNew: true,
 		},
 		"locality": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
 		},
 		"province": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
 		},
 		"country": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
 		},
 		"postal_code": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			ForceNew:      true,
+			PromoteSingle: true,
 		},
 		"serial_number": &schema.Schema{
 			Type:     schema.TypeString,

--- a/tls/resource_cert_request_test.go
+++ b/tls/resource_cert_request_test.go
@@ -15,6 +15,7 @@ func TestCertRequest(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
+			// Test deprecated form of subject with string values
 			r.TestStep{
 				Config: fmt.Sprintf(`
                     resource "tls_cert_request" "test1" {
@@ -51,12 +52,10 @@ EOT
                 `, testPrivateKey),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
-
 					got, ok := gotUntyped.(string)
 					if !ok {
 						return fmt.Errorf("output for \"key_pem_1\" is not a string")
 					}
-
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
 						return fmt.Errorf("key is missing CSR PEM preamble")
 					}
@@ -92,7 +91,6 @@ EOT
 					if expected, got := "95559-1227", csr.Subject.PostalCode[0]; got != expected {
 						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
 					}
-
 					if expected, got := 2, len(csr.DNSNames); got != expected {
 						return fmt.Errorf("incorrect number of DNS names: expected %v, got %v", expected, got)
 					}
@@ -100,9 +98,8 @@ EOT
 						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
 					}
 					if expected, got := "example.net", csr.DNSNames[1]; got != expected {
-						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
+						return fmt.Errorf("incorrect DNS name 1: expected %v, got %v", expected, got)
 					}
-
 					if expected, got := 2, len(csr.IPAddresses); got != expected {
 						return fmt.Errorf("incorrect number of IP addresses: expected %v, got %v", expected, got)
 					}
@@ -110,36 +107,36 @@ EOT
 						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
 					}
 					if expected, got := "127.0.0.2", csr.IPAddresses[1].String(); got != expected {
-						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+						return fmt.Errorf("incorrect IP address 1: expected %v, got %v", expected, got)
 					}
 
 					return nil
 				},
 			},
+			// Test that default subject values are go zero values. However subject field cannot be completely empty,
+			// so we need two tests to cover all the cases.
 			r.TestStep{
 				Config: fmt.Sprintf(`
-                    resource "tls_cert_request" "test2" {
-                        subject {
-						serial_number = "42"
+                   resource "tls_cert_request" "test2a" {
+                       subject {
+							serial_number = "42"
 						}
 
-                        key_algorithm = "RSA"
-                        private_key_pem = <<EOT
+                       key_algorithm = "RSA"
+                       private_key_pem = <<EOT
 %s
 EOT
-                    }
-                    output "key_pem_2" {
-                        value = "${tls_cert_request.test2.cert_request_pem}"
-                    }
-                `, testPrivateKey),
+                   }
+                   output "key_pem_2a" {
+                       value = "${tls_cert_request.test2a.cert_request_pem}"
+                   }
+				`, testPrivateKey),
 				Check: func(s *terraform.State) error {
-					gotUntyped := s.RootModule().Outputs["key_pem_2"].Value
-
+					gotUntyped := s.RootModule().Outputs["key_pem_2a"].Value
 					got, ok := gotUntyped.(string)
 					if !ok {
-						return fmt.Errorf("output for \"key_pem_2\" is not a string")
+						return fmt.Errorf("output for \"key_pem_2a\" is not a string")
 					}
-
 					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
 						return fmt.Errorf("key is missing CSR PEM preamble")
 					}
@@ -154,32 +151,176 @@ EOT
 					if expected, got := "", csr.Subject.CommonName; got != expected {
 						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.Organization); got != expected {
+					if got := csr.Subject.Organization; got != nil {
+						return fmt.Errorf("incorrect subject organization: expected nil, got %v", got)
+					}
+					if got := csr.Subject.OrganizationalUnit; got != nil {
+						return fmt.Errorf("incorrect subject organizational unit: expected nil, got %v", got)
+					}
+					if got := csr.Subject.StreetAddress; got != nil {
+						return fmt.Errorf("incorrect subject street address: expected nil, got %v", got)
+					}
+					if got := csr.Subject.Locality; got != nil {
+						return fmt.Errorf("incorrect subject locality: expected nil, got %v", got)
+					}
+					if got := csr.Subject.Province; got != nil {
+						return fmt.Errorf("incorrect subject province: expected nil, got %v", got)
+					}
+					if got := csr.Subject.Country; got != nil {
+						return fmt.Errorf("incorrect subject country: expected nil, got %v", got)
+					}
+					if got := csr.Subject.PostalCode; got != nil {
+						return fmt.Errorf("incorrect subject postal code: expected nil, got %v", got)
+					}
+					if got := csr.DNSNames; got != nil {
+						return fmt.Errorf("incorrect list of DNS names: expected nil, got %v", got)
+					}
+					if got := csr.IPAddresses; got != nil {
+						return fmt.Errorf("incorrect list of IP addresses: expected nil, got %v", got)
+					}
+
+					return nil
+				},
+			},
+			r.TestStep{
+				Config: fmt.Sprintf(`
+                   resource "tls_cert_request" "test2b" {
+                       subject {
+							common_name = "forty-two"
+						}
+
+                       key_algorithm = "RSA"
+                       private_key_pem = <<EOT
+%s
+EOT
+                   }
+                   output "key_pem_2b" {
+                       value = "${tls_cert_request.test2b.cert_request_pem}"
+                   }
+				`, testPrivateKey),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["key_pem_2b"].Value
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem_2b\" is not a string")
+					}
+					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
+						return fmt.Errorf("key is missing CSR PEM preamble")
+					}
+					block, _ := pem.Decode([]byte(got))
+					csr, err := x509.ParseCertificateRequest(block.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing CSR: %s", err)
+					}
+					if expected, got := "forty-two", csr.Subject.CommonName; got != expected {
+						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
+					}
+
+					return nil
+				},
+			},
+			// Test list of strings attributes
+			r.TestStep{
+				Config: fmt.Sprintf(`
+                   resource "tls_cert_request" "test3a" {
+                       subject {
+							serial_number = "43"
+							common_name = "hey ho"
+							organization = ["Testy", "McTesterFace"]
+							organizational_unit = ["Unit test"]
+							street_address = ["123 Drury Lane", "Nowhere", "Montana"]
+							locality = ["USA"]
+							province = ["Provincial"]
+							country = ["Candy Mountain"]
+							postal_code = ["78739"]
+						}
+
+                       key_algorithm = "RSA"
+                       private_key_pem = <<EOT
+%s
+EOT
+                   }
+                   output "key_pem_3a" {
+                       value = "${tls_cert_request.test3a.cert_request_pem}"
+                   }
+				`, testPrivateKey),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["key_pem_3a"].Value
+
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem_3a\" is not a string")
+					}
+					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE REQUEST----") {
+						return fmt.Errorf("key is missing CSR PEM preamble")
+					}
+					block, _ := pem.Decode([]byte(got))
+					csr, err := x509.ParseCertificateRequest(block.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing CSR: %s", err)
+					}
+					if expected, got := "43", csr.Subject.SerialNumber; got != expected {
+						return fmt.Errorf("incorrect subject serial number: expected %v, got %v", expected, got)
+					}
+					if expected, got := "hey ho", csr.Subject.CommonName; got != expected {
+						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
+					}
+					if expected, got := 2, len(csr.Subject.Organization); got != expected {
 						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.OrganizationalUnit); got != expected {
+					if expected, got := "Testy", csr.Subject.Organization[0]; got != expected {
+						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
+					}
+					if expected, got := "McTesterFace", csr.Subject.Organization[1]; got != expected {
+						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
+					}
+					if expected, got := 1, len(csr.Subject.OrganizationalUnit); got != expected {
+						return fmt.Errorf("incorrect subject organization_unit: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Unit test", csr.Subject.OrganizationalUnit[0]; got != expected {
 						return fmt.Errorf("incorrect subject organizational unit: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.StreetAddress); got != expected {
+					if expected, got := 3, len(csr.Subject.StreetAddress); got != expected {
 						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.Locality); got != expected {
+					if expected, got := "123 Drury Lane", csr.Subject.StreetAddress[0]; got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Nowhere", csr.Subject.StreetAddress[1]; got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Montana", csr.Subject.StreetAddress[2]; got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := 1, len(csr.Subject.Locality); got != expected {
 						return fmt.Errorf("incorrect subject locality: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.Province); got != expected {
+					if expected, got := "USA", csr.Subject.Locality[0]; got != expected {
+						return fmt.Errorf("incorrect subject locality: expected %v, got %v", expected, got)
+					}
+					if expected, got := 1, len(csr.Subject.Province); got != expected {
 						return fmt.Errorf("incorrect subject province: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.Country); got != expected {
+					if expected, got := "Provincial", csr.Subject.Province[0]; got != expected {
+						return fmt.Errorf("incorrect subject province: expected %v, got %v", expected, got)
+					}
+					if expected, got := 1, len(csr.Subject.Country); got != expected {
 						return fmt.Errorf("incorrect subject country: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.Subject.PostalCode); got != expected {
+					if expected, got := "Candy Mountain", csr.Subject.Country[0]; got != expected {
+						return fmt.Errorf("incorrect subject country: expected %v, got %v", expected, got)
+					}
+					if expected, got := 1, len(csr.Subject.PostalCode); got != expected {
 						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.DNSNames); got != expected {
-						return fmt.Errorf("incorrect number of DNS names: expected %v, got %v", expected, got)
+					if expected, got := "78739", csr.Subject.PostalCode[0]; got != expected {
+						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
 					}
-					if expected, got := 0, len(csr.IPAddresses); got != expected {
-						return fmt.Errorf("incorrect number of IP addresses: expected %v, got %v", expected, got)
+					if got := csr.DNSNames; got != nil {
+						return fmt.Errorf("incorrect list of DNS names: expected nil, got %v", got)
+					}
+					if got := csr.IPAddresses; got != nil {
+						return fmt.Errorf("incorrect list of IP addresses: expected nil, got %v", got)
 					}
 
 					return nil

--- a/website/docs/r/cert_request.html.md
+++ b/website/docs/r/cert_request.html.md
@@ -33,7 +33,10 @@ resource "tls_cert_request" "example" {
 
   subject {
     common_name  = "example.com"
-    organization = "ACME Examples, Inc"
+    organization = ["ACME Examples, Inc"]
+    # Specifying a simple string instead of a list of strings is deprecated
+    # but is works for now
+    # organization = "ACME Examples, Inc"
   }
 }
 ```
@@ -47,7 +50,7 @@ in `private_key_pem`.
 
 * `private_key_pem` - (Required) PEM-encoded private key data. This can be
 read from a separate file using the ``file`` interpolation function. Only
-an irreversable secure hash of the private key will be stored in the Terraform
+an irreversible secure hash of the private key will be stored in the Terraform
 state.
 
 * `subject` - (Required) The subject for which a certificate is being requested. This is
@@ -59,25 +62,40 @@ a nested configuration block whose structure is described below.
 
 The nested `subject` block accepts the following arguments, all optional, with their meaning
 corresponding to the similarly-named attributes defined in
-[RFC5290](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
+[RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.1.2.4):
 
 * `common_name` (string)
 
-* `organization` (string)
+* `organization` (list of strings)
 
-* `organizational_unit` (string)
+* `organizational_unit` (list of strings)
 
 * `street_address` (list of strings)
 
-* `locality` (string)
+* `locality` (list of strings)
 
-* `province` (string)
+* `province` (list of strings)
 
-* `country` (string)
+* `country` (list of strings)
 
-* `postal_code` (string)
+* `postal_code` (list of strings)
 
 * `serial_number` (string)
+
+**NOTE** In provider releases prior to 1.2.0, the `organization`, `organizational_unit`,
+`locality`, `province`, `country`, and `postal_code` attributes were of type string.
+In accordance with RFC 5290, these attributes now take values of type list of strings,
+and using values of type string is now deprecated.
+
+However, a simple string is currently accepted for these
+attributes for compatibility reasons, and is converted internally to a list of
+a single string. In the future, we may remove this compatibility feature, so please
+update your configuration files.
+
+If you have existing Terraform state that was created with previous verisons of the TLs
+provider, running `terraform plan` or `terraform apply` will force any resources
+dependent on a `subject` field to be destroyed and recreated. This may cause
+certificates to be regenerated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
 The `organization`, `organizational_unit`, `locality`, `province`, `country`, and `postal_code` attributes now take list of strings values instead of string values. This allows users to specify subject DNs with multiple values for these attributes, as allowed by RFC 5280.

Backwards compatibility is maintained by using the `PromoteSingle: true` option for the attributes. However, this will force new resources the first time the new provider is used, because the saved state (string) does not match the new state (list of strings).

The doc is updated to say the old forms are deprecated and may be removed in the future.

