### PR TITLE
Added the optional subject_key_id parameter.

### DIFF
--- a/tls/data_source_public_key_test.go
+++ b/tls/data_source_public_key_test.go
@@ -21,7 +21,7 @@ D9Hk2MajZuFnJiqj1QIDAQAB
 )
 
 func TestAccPublicKey_dataSource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.UnitTest(t, resource.TestCase{
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{

--- a/tls/resource_cert_request_test.go
+++ b/tls/resource_cert_request_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCertRequest(t *testing.T) {
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{

--- a/tls/resource_certificate.go
+++ b/tls/resource_certificate.go
@@ -130,6 +130,13 @@ func resourceCertificateCommonSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+
+		"set_subject_key_id": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If true, the generated certificate will include a subject key identifier.",
+			ForceNew:    true,
+		},
 	}
 }
 
@@ -159,6 +166,13 @@ func createCertificate(d *schema.ResourceData, template, parent *x509.Certificat
 	if d.Get("is_ca_certificate").(bool) {
 		template.IsCA = true
 
+		template.SubjectKeyId, err = generateSubjectKeyID(pub)
+		if err != nil {
+			return fmt.Errorf("failed to set subject key identifier: %s", err)
+		}
+	}
+
+	if d.Get("set_subject_key_id").(bool) {
 		template.SubjectKeyId, err = generateSubjectKeyID(pub)
 		if err != nil {
 			return fmt.Errorf("failed to set subject key identifier: %s", err)

--- a/tls/resource_locally_signed_cert_test.go
+++ b/tls/resource_locally_signed_cert_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestLocallySignedCert(t *testing.T) {
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
@@ -146,7 +146,7 @@ func TestLocallySignedCert(t *testing.T) {
 func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 	oldNow := now
 	var previousCert string
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
@@ -223,7 +223,7 @@ func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 func TestAccLocallySignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T) {
 	oldNow := now
 	var previousCert string
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{

--- a/tls/resource_private_key_test.go
+++ b/tls/resource_private_key_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPrivateKeyRSA(t *testing.T) {
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
@@ -105,7 +105,7 @@ func TestPrivateKeyRSA(t *testing.T) {
 }
 
 func TestPrivateKeyECDSA(t *testing.T) {
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{

--- a/tls/resource_self_signed_cert_test.go
+++ b/tls/resource_self_signed_cert_test.go
@@ -211,7 +211,7 @@ EOT
 func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 	oldNow := now
 	var previousCert string
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
@@ -288,7 +288,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T) {
 	oldNow := now
 	var previousCert string
-	r.Test(t, r.TestCase{
+	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{

--- a/website/docs/r/locally_signed_cert.html.md
+++ b/website/docs/r/locally_signed_cert.html.md
@@ -67,6 +67,10 @@ The following arguments are supported:
   generated certificate. Defaults to `false`, meaning that the certificate does not represent
   a certificate authority.
 
+* `set_subject_key_id` - (Optional) If `true`, the certificate will include
+  the subject key identifier. Defaults to `false`, in which case the subject
+  key identifier is not set at all.
+
 The `allowed_uses` list accepts the following keywords, combining the set of flags defined by
 both [Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) and
 [Extended Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.12) in

--- a/website/docs/r/self_signed_cert.html.md
+++ b/website/docs/r/self_signed_cert.html.md
@@ -90,6 +90,10 @@ The following arguments are supported:
   generated certificate. Defaults to `false`, meaning that the certificate does not represent
   a certificate authority.
 
+* `set_subject_key_id` - (Optional) If `true`, the certificate will include
+  the subject key identifier. Defaults to `false`, in which case the subject
+  key identifier is not set at all.
+
 The `allowed_uses` list accepts the following keywords, combining the set of flags defined by
 both [Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) and
 [Extended Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.12) in


### PR DESCRIPTION
Some software like Kubernetes requires the subject_key_id field included in the tls certificate.
