### PR TITLE
tls: mark all fields with private keys as sensitive

### DIFF
--- a/tls/data_source_public_key.go
+++ b/tls/data_source_public_key.go
@@ -14,6 +14,7 @@ func dataSourcePublicKey() *schema.Resource {
 			"private_key_pem": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				Description: "PEM formatted string to use as the private key",
 			},
 			"algorithm": {

--- a/tls/resource_cert_request.go
+++ b/tls/resource_cert_request.go
@@ -52,6 +52,7 @@ func resourceCertRequest() *schema.Resource {
 				Required:    true,
 				Description: "PEM-encoded private key that the certificate will belong to",
 				ForceNew:    true,
+				Sensitive:   true,
 				StateFunc: func(v interface{}) string {
 					return hashForState(v.(string))
 				},

--- a/tls/resource_locally_signed_cert.go
+++ b/tls/resource_locally_signed_cert.go
@@ -31,6 +31,7 @@ func resourceLocallySignedCert() *schema.Resource {
 		Required:    true,
 		Description: "PEM-encoded CA private key used to sign the certificate",
 		ForceNew:    true,
+		Sensitive:   true,
 		StateFunc: func(v interface{}) string {
 			return hashForState(v.(string))
 		},

--- a/tls/resource_private_key.go
+++ b/tls/resource_private_key.go
@@ -77,8 +77,9 @@ func resourcePrivateKey() *schema.Resource {
 			},
 
 			"private_key_pem": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"public_key_pem": {

--- a/tls/resource_self_signed_cert.go
+++ b/tls/resource_self_signed_cert.go
@@ -50,6 +50,7 @@ func resourceSelfSignedCert() *schema.Resource {
 		Required:    true,
 		Description: "PEM-encoded private key that the certificate will belong to",
 		ForceNew:    true,
+		Sensitive:   true,
 		StateFunc: func(v interface{}) string {
 			return hashForState(v.(string))
 		},


### PR DESCRIPTION
Terraform >= 0.12.0 shows all resource fields during planning, so
all generated private keys my end up in STDOUT/logs, which is potential
security threat.

This commit sets Sensitive: true to all fields which store private keys.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>